### PR TITLE
Upgrade Smarty to 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "tedivm/stash": "0.12.*",
         "dflydev/apache-mime-types": "1.0.*",
         "jeremykendall/php-domain-parser": "=1.3.1|~1.4.6",
-        "smarty/smarty": "2.6.28",
+        "smarty/smarty": "3.1.21",
         "ezyang/htmlpurifier": "4.6.0",
         "monolog/monolog": "1.10.*",
         "maximebf/debugbar": "1.10.*",


### PR DESCRIPTION
This requires major changes to Xoops/XoopsCore. This is only for testing until further notice.